### PR TITLE
fix: update Docker username and image path in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: containers.chewed-k8s.net/flags-gg/dashboard
+          images: containers.chewed-k8s.net/retro-board/retro-board
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{raw}}
@@ -42,7 +42,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: containers.chewed-k8s.net
-          username: robot$flags-gg+github
+          username: robot$retro-board+github
           password: ${{ secrets.CONTAINERS_KEY }}
       - name: Build and Push
         id: docker_build


### PR DESCRIPTION
Change the Docker username from `robot$flags-gg+github` to  `robot$retro-board+github` and update the image path from  `containers.chewed-k8s.net/flags-gg/dashboard` to  `containers.chewed-k8s.net/retro-board/retro-board` in the  GitHub Actions workflow. These changes reflect the new