### PR TITLE
fix: update QODANA_TOKEN secret in workflow

### DIFF
--- a/.github/workflows/drafter.yml
+++ b/.github/workflows/drafter.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           upload-result: true
         env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_362254779 }}
   update_release_draft:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Update the QODANA_TOKEN in the drafter.yml workflow to use the new  secret format. This change ensures that the workflow has access to  the correct token for authentication during the release draft  process.