### PR TITLE
refactor: use ReactNode type for children prop

### DIFF
--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -4,7 +4,7 @@ import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
-import { useState } from "react";
+import { useState, ReactNode } from "react";
 import SuperJSON from "superjson";
 
 import { type AppRouter } from "~/server/api/root";
@@ -36,7 +36,7 @@ export type RouterInputs = inferRouterInputs<AppRouter>;
  */
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
-export function TRPCReactProvider(props: { children: React.ReactNode }) {
+export function TRPCReactProvider(props: { children: ReactNode }) {
   const queryClient = getQueryClient();
 
   const [trpcClient] = useState(() =>


### PR DESCRIPTION
Update the TRPCReactProvider component to use the ReactNode type  for the children prop instead of React.ReactNode. This change  improves consistency and simplifies the import statement by  allowing the use of a single type alias.